### PR TITLE
Puck waypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,7 @@ import { PuckWaypoint } from '@dosomething/puck-client';
 
 const Example = () => (
   <div className="container" style={{ height: '1000px' }}>
-    <PuckWaypoint name="half-way-point">
-      <div className="half" style={{ margin-top: '500px'}}>
-        <h1>sup</h1>
-      </div>
-    </PuckWaypoint>
+    <PuckWaypoint name="half-way-point" />
   </div>
 );
 ```

--- a/README.md
+++ b/README.md
@@ -116,3 +116,26 @@ function onClick() {
 All of the same params from the React version can be used here, but some have been intentionally omitted (eg: `history`) because they are irrelevant for non-React Router based applications.
 
 When using the pure Puck engine, simply call `trackEvent` on it.
+
+## React Waypoints
+
+Use Waypoints to track when users scroll past a certain point.
+
+```js
+import { PuckWaypoint } from '@dosomething/puck-client';
+
+const Example = () => (
+  <div className="container" style={{ height: '1000px' }}>
+    <PuckWaypoint name="half-way-point">
+      <div className="half" style={{ margin-top: '500px'}}>
+        <h1>sup</h1>
+      </div>
+    </PuckWaypoint>
+  </div>
+);
+```
+
+Available props:
+**name**: Required. Name of the waypoint.
+**onlyOnce**: Optional (Defaults  true). Waypoint only emits an event one time.
+**waypointData**: Optional (Defaults null). Additional data to track on the waypoint event.

--- a/lib/Waypoint.js
+++ b/lib/Waypoint.js
@@ -4,7 +4,7 @@ import Observer from '@researchgate/react-intersection-observer';
 import 'intersection-observer'; // TODO: Only import if polyfill is needed
 import Connector from './Connector';
 
-class Ruler extends React.Component {
+class Waypoint extends React.Component {
   constructor(props) {
     super(props);
 
@@ -41,12 +41,12 @@ class Ruler extends React.Component {
   }
 }
 
-Ruler.defaultProps = {
+Waypoint.defaultProps = {
   onlyOnce: true,
   waypointData: null,
 };
 
-Ruler.propTypes = {
+Waypoint.propTypes = {
   children: PropTypes.node.isRequired,
   name: PropTypes.string.isRequired,
   onlyOnce: PropTypes.bool,
@@ -54,4 +54,4 @@ Ruler.propTypes = {
   waypointData: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
 
-export default Connector(Ruler);
+export default Connector(Waypoint);

--- a/lib/Waypoint.js
+++ b/lib/Waypoint.js
@@ -24,7 +24,7 @@ class Waypoint extends React.Component {
   }
 
   render() {
-    const { children, onlyOnce } = this.props;
+    const { onlyOnce } = this.props;
 
     const options = {
       onChange: this.handleIntersection,
@@ -33,9 +33,7 @@ class Waypoint extends React.Component {
 
     return (
       <Observer {...options}>
-        <div>
-          { React.Children.only(children) }
-        </div>
+        <div />
       </Observer>
     );
   }
@@ -47,7 +45,6 @@ Waypoint.defaultProps = {
 };
 
 Waypoint.propTypes = {
-  children: PropTypes.node.isRequired,
   name: PropTypes.string.isRequired,
   onlyOnce: PropTypes.bool,
   trackEvent: PropTypes.func.isRequired,

--- a/lib/Waypoint.js
+++ b/lib/Waypoint.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Observer from '@researchgate/react-intersection-observer';
+import 'intersection-observer'; // TODO: Only import if polyfill is needed
+import Connector from './Connector';
+
+class Ruler extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.handleIntersection = this.handleIntersection.bind(this);
+  }
+
+  handleIntersection(event) {
+    const { isIntersecting } = event;
+    if (! isIntersecting) return;
+
+    const { name, trackEvent, waypointData } = this.props;
+
+    trackEvent('waypoint reached', {
+      waypointName: name,
+      waypointData,
+    });
+  }
+
+  render() {
+    const { children, onlyOnce } = this.props;
+
+    const options = {
+      onChange: this.handleIntersection,
+      onlyOnce,
+    };
+
+    return (
+      <Observer {...options}>
+        <div>
+          { React.Children.only(children) }
+        </div>
+      </Observer>
+    );
+  }
+}
+
+Ruler.defaultProps = {
+  onlyOnce: true,
+  waypointData: null,
+};
+
+Ruler.propTypes = {
+  children: PropTypes.node.isRequired,
+  name: PropTypes.string.isRequired,
+  onlyOnce: PropTypes.bool,
+  trackEvent: PropTypes.func.isRequired,
+  waypointData: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+};
+
+export default Connector(Ruler);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 export PuckProvider from './Provider';
 export PuckConnector from './Connector';
+export PuckWaypoint from './Waypoint';
 
 export Engine from './Engine';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dosomething/puck-client",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7769,11 +7769,6 @@
           }
         }
       }
-    },
-    "react-intersection-observer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-3.0.2.tgz",
-      "integrity": "sha512-ryMe7DKmm21D25MmmaQdNDg+ONs/yWwFpn4vD6xeMigOZfV1ovHYDWpgnF4vwoV+MdNxkiqmTVOHbPyNpH3WZQ=="
     },
     "read-pkg": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -233,6 +233,41 @@
         }
       }
     },
+    "@researchgate/react-intersection-observer": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@researchgate/react-intersection-observer/-/react-intersection-observer-0.6.0.tgz",
+      "integrity": "sha512-rbkRGUw15e05TnWtRI9xhcsgCiGFRnhJ9dYPii4uHMo2ZaboJLHKyJiVPNjyRO3UtXPj+8uTVbkDqkr22G5G3w==",
+      "requires": {
+        "invariant": "2.2.2",
+        "prop-types": "15.6.0"
+      },
+      "dependencies": {
+        "fbjs": {
+          "version": "0.8.16",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+          "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.14"
+          }
+        },
+        "prop-types": {
+          "version": "15.6.0",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
+          "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1"
+          }
+        }
+      }
+    },
     "abbrev": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
@@ -5369,11 +5404,15 @@
       "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=",
       "dev": true
     },
+    "intersection-observer": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.5.0.tgz",
+      "integrity": "sha512-8Zgt4ijlyvIrQVTA7MPb2W9+KhoetrAbxlh0RmTGxpx0+ZsAXvy7IsbNnZIrqZ6TddAdWeQj49x7Ph7Ir6KRkA=="
+    },
     "invariant": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "dev": true,
       "requires": {
         "loose-envify": "1.3.1"
       }
@@ -7693,6 +7732,48 @@
         "object-assign": "4.1.1",
         "prop-types": "15.5.10"
       }
+    },
+    "react-dom": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
+      "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
+      "requires": {
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.0"
+      },
+      "dependencies": {
+        "fbjs": {
+          "version": "0.8.16",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+          "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.14"
+          }
+        },
+        "prop-types": {
+          "version": "15.6.0",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
+          "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1"
+          }
+        }
+      }
+    },
+    "react-intersection-observer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-3.0.2.tgz",
+      "integrity": "sha512-ryMe7DKmm21D25MmmaQdNDg+ONs/yWwFpn4vD6xeMigOZfV1ovHYDWpgnF4vwoV+MdNxkiqmTVOHbPyNpH3WZQ=="
     },
     "read-pkg": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dosomething/puck-client",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "The client for Puck",
   "main": "build/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "NODE_ENV=development webpack --watch",
     "build:dev": "NODE_ENV=development webpack",
     "build": "NODE_ENV=production webpack && babel lib --out-dir build",
-    "prepublish": "npm run build"
+    "prepublishOnly": "npm run build"
   },
   "babel": {
     "presets": [
@@ -36,9 +36,15 @@
     "webpack": "^3.5.6",
     "webpack-dev-server": "^2.7.1"
   },
+  "peerDependencies": {
+    "react": "*"
+  },
   "dependencies": {
+    "@researchgate/react-intersection-observer": "^0.6.0",
+    "intersection-observer": "^0.5.0",
     "prop-types": "^15.5.10",
     "react": "^15.6.1",
+    "react-dom": "^16.2.0",
     "socket.io-client": "^2.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,9 +36,6 @@
     "webpack": "^3.5.6",
     "webpack-dev-server": "^2.7.1"
   },
-  "peerDependencies": {
-    "react": "*"
-  },
   "dependencies": {
     "@researchgate/react-intersection-observer": "^0.6.0",
     "intersection-observer": "^0.5.0",


### PR DESCRIPTION
This PR lets developers add "Waypoints" on the page, which can track if the child nodes are visible on the users' screen. Waypoints can include custom information in order to get better analytical insights on what is being viewed.

Additionally, I bumped the version number, added documentation, and installed the required packages. I also updated the package.json spec for npm 5