### PR TITLE
Removing UUID from client

### DIFF
--- a/lib/Engine.js
+++ b/lib/Engine.js
@@ -11,7 +11,7 @@ const DEVICE_ID = 'DEVICE_ID';
 const LANDING_TIMESTAMP = 'LANDING_TIMESTAMP';
 const HEARTBEAT_TIMESTAMP = 'HEARTBEAT_TIMESTAMP';
 const SESSION_REFERRER = 'SESSION_REFERRER';
-const SPEC_VERSION = '1.2.0';
+const SPEC_VERSION = '1.3.0';
 
 class Engine {
   constructor(params) {

--- a/lib/Engine.js
+++ b/lib/Engine.js
@@ -4,7 +4,7 @@ import io from 'socket.io-client';
 
 import {
   generateUniqueId, isSessionExpired,
-  getUrlData, getBrowserSize, uuidv4,
+  getUrlData, getBrowserSize,
 } from './helpers';
 
 const DEVICE_ID = 'DEVICE_ID';
@@ -130,7 +130,6 @@ class Engine {
         source,
       },
       meta: {
-        id: uuidv4(),
         timestamp: Date.now(),
         version: SPEC_VERSION,
       },

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -97,18 +97,3 @@ export function getBrowserSize() {
 
   return breakpoints.find(breakpoint => breakpoint.test(screenWidth)).name;
 }
-
-/**
- * Generate a uuidv4 id.
- *
- * @see https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
- * @return {String}
- */
-export function uuidv4() {
-  /* eslint-disable */
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
-    return v.toString(16);
-  });
-  /* eslint-enable */
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dosomething/puck-client",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dosomething/puck-client",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "The client for Puck",
   "main": "build/index.js",
   "scripts": {


### PR DESCRIPTION
- Removing the setting of the `meta`, `id` field.
- Removing `uuid` helper function.
- Bumping version to `1.4.0`
- Bumping Spec version to `1.3.0`