### PR TITLE
Add isAuthenticated to user fields

### DIFF
--- a/lib/Engine.js
+++ b/lib/Engine.js
@@ -15,10 +15,11 @@ const SPEC_VERSION = '1.3.0';
 
 class Engine {
   constructor(params) {
-    const { source, puckUrl, getUser, history } = params;
+    const { source, puckUrl, getUser, isAuthenticated, history } = params;
 
     this.source = source || null;
     this.getUser = getUser || (() => null);
+    this.isAuthenticated = isAuthenticated || (() => null);
     this.history = history || { listen: () => {} };
 
     this.puckUrl = puckUrl;
@@ -118,8 +119,8 @@ class Engine {
    */
   dispatchEvent(name, data = null) {
     const {
-      source, getUser, deviceId,
-      landingTimestamp, referrer,
+      source, getUser, isAuthenticated,
+      deviceId, landingTimestamp, referrer,
     } = this;
 
     const sessionId = `${deviceId}${landingTimestamp}`;
@@ -136,6 +137,7 @@ class Engine {
       user: {
         ip: null,
         northstarId: getUser(),
+        isAuthenticated: isAuthenticated(),
         deviceId,
       },
       page: {


### PR DESCRIPTION
# What's this PR do?

This PR adds `isAuthenticated` to the list of `user` fields returned by Puck events

# Relevant tickets
[Pivotal ID #158838971](https://www.pivotaltracker.com/story/show/158838971)