### PR TITLE
Create CommonJS and ES module builds.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Builds
 dist/
-build/
+cjs/
+es/
 
 # Ignore dependencies
 node_modules/

--- a/package.json
+++ b/package.json
@@ -2,13 +2,17 @@
   "name": "@dosomething/puck-client",
   "version": "1.5.1",
   "description": "The client for Puck",
-  "main": "build/index.js",
+  "module": "es/index.js",
+  "main": "cjs/index.js",
   "scripts": {
     "test": "npm run test",
     "lint": "eslint",
     "start": "NODE_ENV=development webpack --watch",
     "build:dev": "NODE_ENV=development webpack",
-    "build": "NODE_ENV=production webpack && babel lib --out-dir build",
+    "build:browser": "NODE_ENV=production webpack",
+    "build:es": "NODE_ENV=production babel lib --out-dir es",
+    "build:cjs": "NODE_ENV=test babel lib --out-dir cjs",
+    "build": "npm run build:browser && npm run build:es && npm run build:cjs",
     "prepublishOnly": "npm run build"
   },
   "babel": {


### PR DESCRIPTION
Noticed this one when updating dependencies in Phoenix – our new Webpack config does _not_ compile ES6 modules to their CommonJS equivalents by default. In general, this is good because it lets Webpack handle tree-shaking, but it causes [issues with Jest tests](https://app.wercker.com/dosomething/phoenix-next/runs/build/5b56200e8b0b3d000681d8ce?step=5b56204e108d3700061533bf), which need to run in Node.

This pull request updates our build process to create both ES & CommonJS builds, and offer them up in the `package.json` under the `module` and `main` fields so tools can grab the appropriate version.