### PR TITLE
Update Waypoint 'Only Once' functionality

### DIFF
--- a/lib/Waypoint.js
+++ b/lib/Waypoint.js
@@ -26,8 +26,6 @@ class Waypoint extends React.Component {
   }
 
   render() {
-    const { onlyOnce } = this.props;
-
     const options = {
       onChange: this.handleIntersection,
     };
@@ -41,13 +39,11 @@ class Waypoint extends React.Component {
 }
 
 Waypoint.defaultProps = {
-  onlyOnce: true,
   waypointData: null,
 };
 
 Waypoint.propTypes = {
   name: PropTypes.string.isRequired,
-  onlyOnce: PropTypes.bool,
   trackEvent: PropTypes.func.isRequired,
   waypointData: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };

--- a/lib/Waypoint.js
+++ b/lib/Waypoint.js
@@ -11,7 +11,7 @@ class Waypoint extends React.Component {
     this.handleIntersection = this.handleIntersection.bind(this);
   }
 
-  handleIntersection(event) {
+  handleIntersection(event, unobserve) {
     const { isIntersecting } = event;
     if (! isIntersecting) return;
 
@@ -21,6 +21,8 @@ class Waypoint extends React.Component {
       waypointName: name,
       waypointData,
     });
+
+    unobserve();
   }
 
   render() {
@@ -28,7 +30,6 @@ class Waypoint extends React.Component {
 
     const options = {
       onChange: this.handleIntersection,
-      onlyOnce,
     };
 
     return (


### PR DESCRIPTION
## What's the deal?
We've been getting console errors regarding a soon to be deprecated option -`onlyOnce`- we use to ensure the waypoint intersection change event is only triggered once in the `Waypoint` component (which uses the `react-intersection-observer`).

This PR updates this functionality accordingly.

![image](https://user-images.githubusercontent.com/12417657/45702155-108fe680-bb3f-11e8-9941-6be8e13515ea.png)

[more context from the React Intersection Observer docs](https://researchgate.github.io/react-intersection-observer/?selectedKind=Examples&selectedStory=Once&full=0&down=1&left=1&panelRight=1&downPanel=REACT_STORYBOOK%2Freadme%2Fpanel)

> Use the second argument of onChange(event, unobserve) to customize how you prefer to stop observing the target. You can also set the prop disabled=true in the <Observer> element to achieve the same effect.

> Deprecated: ~The option onlyOnce applied to the component will only trigger the event one time: when the target detects isIntersecting is truthy. This is specially useful when you need a disposable observer, and you need to prevent re-rendering the element later:~

[Pivotal ID #159448616](https://www.pivotaltracker.com/story/show/159448616)