### PR TITLE
Add Error Handler Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,7 @@ Available props:
 **name**: Required. Name of the waypoint.
 **onlyOnce**: Optional (Defaults  true). Waypoint only emits an event one time.
 **waypointData**: Optional (Defaults null). Additional data to track on the waypoint event.
+
+
+## Error Handling (Optional)
+The `PuckProvider` and `Engine` both accept an `onError` parameter function, which will be invoked whenever the internally utilized socket emits a [`'connect-error'`](https://socket.io/docs/client-api/#Event-%E2%80%98connect-error%E2%80%99-1) or [`'error'`](https://socket.io/docs/client-api/#Event-%E2%80%98error%E2%80%99) event.

--- a/lib/Engine.js
+++ b/lib/Engine.js
@@ -26,6 +26,9 @@ class Engine {
     this.puckUrl = puckUrl;
     this.socket = puckUrl ? io(puckUrl) : null;
 
+    this.initErrorListener = this.initErrorListener.bind(this);
+    this.initErrorListener();
+
     this.deviceId = localStorage.getItem(DEVICE_ID) || generateUniqueId();
     localStorage.setItem(DEVICE_ID, this.deviceId);
 
@@ -44,6 +47,23 @@ class Engine {
 
     this.ping = this.ping.bind(this);
     this.ping();
+  }
+
+  /**
+   * Listen for socket emitted errors and invoke the onError parameter function.
+   */
+  initErrorListener() {
+    if (! this.socket) {
+      return;
+    }
+
+    this.socket.on('error', (error) => {
+      this.onError('error', error);
+    });
+
+    this.socket.on('connect_error', (error) => {
+      this.onError('connect_error', error);
+    });
   }
 
   /**

--- a/lib/Engine.js
+++ b/lib/Engine.js
@@ -21,7 +21,7 @@ class Engine {
     this.getUser = getUser || (() => null);
     this.isAuthenticated = isAuthenticated || (() => null);
     this.history = history || { listen: () => {} };
-    this.onError = onError || (() => null);
+    this.onError = onError;
 
     this.puckUrl = puckUrl;
     this.socket = puckUrl ? io(puckUrl) : null;
@@ -53,7 +53,7 @@ class Engine {
    * Listen for socket emitted errors and invoke the onError parameter function.
    */
   initErrorListener() {
-    if (! this.socket) {
+    if (! this.socket || ! this.onError) {
       return;
     }
 

--- a/lib/Engine.js
+++ b/lib/Engine.js
@@ -15,12 +15,13 @@ const SPEC_VERSION = '1.4.0';
 
 class Engine {
   constructor(params) {
-    const { source, puckUrl, getUser, isAuthenticated, history } = params;
+    const { source, puckUrl, getUser, isAuthenticated, history, onError } = params;
 
     this.source = source || null;
     this.getUser = getUser || (() => null);
     this.isAuthenticated = isAuthenticated || (() => null);
     this.history = history || { listen: () => {} };
+    this.onError = onError || (() => null);
 
     this.puckUrl = puckUrl;
     this.socket = puckUrl ? io(puckUrl) : null;

--- a/lib/Provider.js
+++ b/lib/Provider.js
@@ -30,6 +30,7 @@ Provider.propTypes = {
   source: PropTypes.string,
   puckUrl: PropTypes.string,
   getUser: PropTypes.func,
+  onError: PropTypes.func,
   history: PropTypes.shape({
     listen: PropTypes.func,
   }),
@@ -42,6 +43,7 @@ Provider.defaultProps = {
   history: null,
   source: null,
   getUser: null,
+  onError: null,
 };
 
 export default Provider;


### PR DESCRIPTION
## What's this PR do?

This PR adds some basic error handling functionality so that applications using the Puck client can define a custom callback function to be run whenever the Engine's socket emits a [`'connect-error'`](https://socket.io/docs/client-api/#Event-%E2%80%98connect-error%E2%80%99-1) or [`'error'`](https://socket.io/docs/client-api/#Event-%E2%80%98error%E2%80%99) event.

## Some Background Perhaps?
This is part of our effort to better understand the large amount of `400` errors we're seeing in our Puck application instance from the [Phoenix](https://github.com/DoSomething/phoenix-next) application

I picked these two error events, since they seemed to be the most specific ones we might be after, though there are some other Socket emitted connection relavent events that didn't feel necessary, but which I fugred could be added if these don't do the trick?

**Q**: How's the naming for the `onError` and `initErrorListener `? Any better ideas or are these ok?

## Relavent Tickets / Issues
https://github.com/DoSomething/puck/issues/17
[Pivotal ID #163064712](https://www.pivotaltracker.com/story/show/163064712)
